### PR TITLE
Overhaul to fix remained bugs

### DIFF
--- a/spec/out_hash_forward_spec.rb
+++ b/spec/out_hash_forward_spec.rb
@@ -16,18 +16,10 @@ describe Fluent::HashForwardOutput do
       port 24224
     </server>
 
-    # ToDo: FIX TO MAKE THIS WORK
-    #<server>
-    #  host 192.168.1.5
-    #  port 24224
-    #  standby true
-    #</server>
-
-    # ToDo: FIX TO MAKE THIS WORK
-    #<secondary>
-    #  type file
-    #  path /var/log/fluent/forward-failed
-    #</secondary>
+    <secondary>
+      type file
+      path /var/log/fluent/forward-failed
+    </secondary>
   ]
   let(:driver) { Fluent::Test::OutputTestDriver.new(Fluent::HashForwardOutput, tag).configure(config) }
 
@@ -39,62 +31,82 @@ describe Fluent::HashForwardOutput do
     end
   end
 
-  describe 'test emit' do
+  describe 'test hashing' do
     let(:tag) { 'test.tag' }
-    let(:time) { Time.now.to_i }
-    let(:es) { Fluent::OneEventStream.new(time, {"a"=>1}) }
-    let(:chain) { Fluent::NullOutputChain.instance }
     let(:config) { CONFIG }
 
-    context 'default behavior' do
+    context 'test consistency' do
       before do
-        Fluent::Engine.stub(:now).and_return(time)
-        Fluent::ForwardOutput.any_instance.should_receive(:emit).with(tag, es, chain)
+        @node = driver.instance.nodes(tag).first
       end
-      it 'should forward' do
-        driver.instance.emit(tag, es, chain)
-      end
-    end
-    
-    context 'test remove_prefix' do
-      let(:tag) { 'test.tag' }
-      let(:config) { CONFIG + %[remove_prefix test] }
-      before do
-        Fluent::Engine.stub(:now).and_return(time)
-        Fluent::HashForwardOutput.any_instance.should_receive(:server_index).with('tag').and_return(0)
-        Fluent::ForwardOutput.any_instance.should_receive(:emit).with('tag', es, chain)
-      end
-      it 'should forward with removing prefix' do
-        driver.instance.emit(tag, es, chain)
+      it 'should forward to the same node' do
+        expect(driver.instance.nodes(tag).first).to eq(@node)
       end
     end
 
-    context 'test add_prefix' do
-      let(:tag) { 'test.tag' }
-      let(:config) { CONFIG + %[add_prefix add] }
+    context 'test distribution' do
+      let(:tag1) { 'test.tag1' }
+      let(:tag2) { 'test.tag2' }
       before do
-        Fluent::Engine.stub(:now).and_return(time)
-        Fluent::HashForwardOutput.any_instance.should_receive(:server_index).with("add.#{tag}").and_return(0)
-        Fluent::ForwardOutput.any_instance.should_receive(:emit).with("add.#{tag}", es, chain)
+        MurmurHash3::V32.stub(:str_hash).with(tag1).and_return(0)
+        MurmurHash3::V32.stub(:str_hash).with(tag2).and_return(1)
+        @node1 = driver.instance.nodes(tag1).first
       end
-      it 'should forward with adding prefix' do
-        driver.instance.emit(tag, es, chain)
+      it 'should forward to the different node' do
+        expect(driver.instance.nodes(tag2).first).not_to eq(@node1)
       end
     end
 
     context 'test hash_key' do
       let(:tag1) { 'test.tag1' }
       let(:tag2) { 'test.tag2' }
-      let(:config) { CONFIG + %[hash_key ${tags[0]}]}
+      let(:config) { CONFIG + %[hash_key ${tags[0..-2]}] }
+      before do
+        @node1 = driver.instance.nodes(tag1).first
+      end
+      it 'should forward to the different node' do
+        expect(driver.instance.nodes(tag2).first).to eq(@node1)
+      end
+    end
+  end
+
+  describe 'test emit' do
+    let(:tag) { 'test.tag' }
+    let(:time) { Time.now.to_i }
+    let(:es) { Array.new(1) }
+    let(:chain) { Fluent::NullOutputChain.instance }
+    let(:config) { CONFIG }
+
+    context 'default behavior' do
       before do
         Fluent::Engine.stub(:now).and_return(time)
-        Fluent::HashForwardOutput.any_instance.should_receive(:server_index).twice.with('test').and_return(0)
-        Fluent::ForwardOutput.any_instance.should_receive(:emit).with(tag1, es, chain)
-        Fluent::ForwardOutput.any_instance.should_receive(:emit).with(tag2, es, chain)
+        node = driver.instance.nodes(tag).first
+        driver.instance.should_receive(:send_data).with(node, tag, es)
       end
-      it 'should forward to tags[0] hash' do
-        driver.instance.emit(tag1, es, chain)
-        driver.instance.emit(tag2, es, chain)
+      it 'should forward' do
+        driver.instance.write_objects(tag, es)
+      end
+    end
+
+    context 'test standby' do
+      let(:config) {
+        CONFIG + %[
+        <server>
+          host 192.168.1.5
+          port 24224
+          standby true
+        </server>
+        ]
+      }
+      before do
+        Fluent::Engine.stub(:now).and_return(time)
+        regular_node = driver.instance.nodes(tag)[0]
+        standby_node = driver.instance.nodes(tag)[1]
+        regular_node.stub(:available?).and_return(false) # stub as regular node is not available
+        driver.instance.should_receive(:send_data).with(standby_node, tag, es)
+      end
+      it 'should forward to the standby node if regular node is not available' do
+        driver.instance.write_objects(tag, es)
       end
     end
   end


### PR DESCRIPTION
I overhauled to fix the ToDo bugs. Now, out_hash_forward extends out_forward plugin, does not plant. (It was difficult to fix following bugs with plant). 

```
# ToDo: FIX TO MAKE THIS WORK
#<server>
#  host 192.168.1.5
#  port 24224
#  standby true
#</server>

# ToDo: FIX TO MAKE THIS WORK
#<secondary>
#  type file
#  path /var/log/fluent/forward-failed
#</secondary>
```
