### PR TITLE
Add config descriptions

### DIFF
--- a/lib/fluent/plugin/out_hash_forward.rb
+++ b/lib/fluent/plugin/out_hash_forward.rb
@@ -9,9 +9,20 @@ class Fluent::HashForwardOutput < Fluent::ForwardOutput
     define_method("log") { $log }
   end
 
+  desc "Use sliced tag as a hash key to determine a forwarding node."
   config_param :hash_key_slice, :string, :default => nil
+  desc "Keepalive connection."
   config_param :keepalive, :bool, :default => false
-  config_param :keepalive_time, :time, :default => nil # infinite
+  desc <<-DESC
+ Keepalive expired time.
+When specified nil, keep connection as long as possible.
+DESC
+  config_param :keepalive_time, :time, :default => nil
+  desc <<-DESC
+The transport protocol to use for heartbeats.
+The default is “udp”, but you can select “tcp” as well.
+Furthermore, in hash_forward, you can also select "none" to disable heartbeat.
+DESC
   config_param :heartbeat_type, :default => :udp do |val|
     case val.downcase
     when 'tcp'

--- a/lib/fluent/plugin/out_hash_forward.rb
+++ b/lib/fluent/plugin/out_hash_forward.rb
@@ -9,6 +9,14 @@ class Fluent::HashForwardOutput < Fluent::ForwardOutput
     define_method("log") { $log }
   end
 
+  # For fluentd v0.12.16 or earlier
+  class << self
+    unless method_defined?(:desc)
+      def desc(description)
+      end
+    end
+  end
+
   desc "Use sliced tag as a hash key to determine a forwarding node."
   config_param :hash_key_slice, :string, :default => nil
   desc "Keepalive connection."


### PR DESCRIPTION
With fluentd 0.12.19, config descriptions are shown like this:

``` log
$ bundle exec fluentd --show-plugin-config output:hash_forward -p lib/fluent/plugin/
2016-01-19 16:32:23 +0900 [info]: Show config for output:hash_forward
2016-01-19 16:32:23 +0900 [info]: 
log_level: string: <nil> # Allows the user to set different levels of logging for each plugin.
buffer_type: string: <"memory">
flush_interval: time: <60>
try_flush_interval: float: <1>
disable_retry_limit: bool: <false>
retry_limit: integer: <17>
retry_wait: time: <1.0>
max_retry_wait: time: <nil>
num_threads: integer: <1>
queued_chunk_flush_interval: time: <1>
send_timeout: time: <60> # The timeout time when sending event logs.
heartbeat_type: : <:udp> # The transport protocol to use for heartbeats.(udp,tcp,none)
heartbeat_interval: time: <1> # The interval of the heartbeat packer.
recover_wait: time: <10> # The wait time before accepting a server fault recovery.
hard_timeout: time: <60> # The hard timeout used to detect server failure.
expire_dns_cache: time: <nil> # Set TTL to expire DNS cache in seconds.
phi_threshold: integer: <16> # The threshold parameter used to detect server faults.
phi_failure_detector: bool: <true> # Use the "Phi accrual failure detector" to detect server failure.
require_ack_response: bool: <false> # Change the protocol to at-least-once.
ack_response_timeout: time: <190> # This option is used when require_ack_response is true.
dns_round_robin: bool: <false> # Enable client-side DNS round robin.
port: integer: <24224>
host: string: <nil>
hash_key_slice: string: <nil> # Use sliced tag as a hash key to determine a forwarding node.
keepalive: bool: <false> # Keepalive connection.
keepalive_time: time: <nil> #  Keepalive expired time.
When specified nil, keep connection as long as possible.

heartbeat_type: : <:udp> # The transport protocol to use for heartbeats.
The default is “udp”, but you can select “tcp” as well.
Furthermore, in hash_forward, you can also select "none" to disable heartbeat.

```
